### PR TITLE
Update dependency.lock to use bintray 1.8.3 plugin

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,37 +1,37 @@
 {
     "compile": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "compileClasspath": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "default": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "integTestCompile": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -39,13 +39,13 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "integTestCompileClasspath": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -53,13 +53,13 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "integTestRuntime": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -67,13 +67,13 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "integTestRuntimeClasspath": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -81,7 +81,7 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
@@ -97,27 +97,27 @@
     },
     "runtime": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "runtimeClasspath": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "testCompile": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -125,13 +125,13 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "testCompileClasspath": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -139,13 +139,13 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "testRuntime": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -153,13 +153,13 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     },
     "testRuntimeClasspath": {
         "com.jfrog.bintray.gradle:gradle-bintray-plugin": {
-            "locked": "1.8.1",
+            "locked": "1.8.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
@@ -167,7 +167,7 @@
             "requested": "6.+"
         },
         "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.7.3",
+            "locked": "4.7.4",
             "requested": "latest.release"
         }
     }


### PR DESCRIPTION
* Update gradle-bintray-plugin to 1.8.3 to resolve bug causing deployments to be unversioned
* Update build-info-extractor-gradle plugin to 4.7.4 as a byproduct of updating gradle-bintray-plugin

Closes #24 