### PR TITLE
Add project test and fix integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ nebula-bintray-publishing
 
 Sets defaults on many of the fields to push `MavenPublication` to bintray. This also covers the new Gradle metadata files.
 
+> if you want to use nebula-bintray plugin with non java projects, use next snippets
+
+```groovy
+bintray {
+    ...
+    componentsForExport = []
+}
+```
+
 LICENSE
 =======
 

--- a/src/main/kotlin/nebula/plugin/bintray/BintrayExtension.kt
+++ b/src/main/kotlin/nebula/plugin/bintray/BintrayExtension.kt
@@ -34,6 +34,7 @@ open class BintrayExtension(objects: ObjectFactory) {
     val websiteUrl: Property<String> = objects.property()
     val issueTrackerUrl: Property<String> = objects.property()
     val vcsUrl: Property<String> = objects.property()
+    val componentsForExport: ListProperty<String> = objects.listProperty(String::class.java)
 
     fun hasSubject(): Boolean = userOrg.isPresent || user.isPresent
 

--- a/src/test/groovy/nebula/plugin/bintray/NebulaBintrayPublishingPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/bintray/NebulaBintrayPublishingPluginIntegrationSpec.groovy
@@ -477,6 +477,7 @@ class NebulaBintrayPublishingPluginIntegrationSpec extends IntegrationSpec {
                 apiUrl = 'http://localhost:${wireMockRule.port()}'
                 pkgName = 'my-plugin'
                 autoPublish = true
+                componentsForExport = ['java']
             }
             
         """
@@ -492,6 +493,37 @@ class NebulaBintrayPublishingPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("Uploading: test/nebula/netflix/publishes-a-plugin-to-bintray-with-gradle-metadata/1.0.0/publishes-a-plugin-to-bintray-with-gradle-metadata-1.0.0.module to repository remote at")
         result.standardOutput.contains("Uploading: test/nebula/netflix/publishes-a-plugin-to-bintray-with-gradle-metadata/maven-metadata.xml to repository remote at")
     }
+
+    def 'should not publish components when set empty componentsForExport'() {
+        given:
+          buildFile << """ 
+            apply plugin: 'java'
+            apply plugin: 'nebula.nebula-bintray'
+                
+            group = 'test.nebula.netflix'
+            version = '1.0.0'
+            description = 'my plugin'
+            
+            bintray {
+                user = 'nebula-plugins'
+                apiKey = 'mykey'
+                apiUrl = 'http://localhost:${wireMockRule.port()}'
+                pkgName = 'my-plugin'
+                autoPublish = true
+                componentsForExport = []
+            }
+            
+        """
+
+          writeHelloWorld()
+
+        when:
+          def result = runTasksSuccessfully('publishAllPublicationsToBintrayRepository')
+
+        then:
+          result.wasUpToDate('publishAllPublicationsToBintrayRepository')
+    }
+
 
 
     void writeHelloWorld(String dottedPackage = 'netflix.hello') {

--- a/src/test/groovy/nebula/plugin/bintray/NebulaBintrayPublishingPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/bintray/NebulaBintrayPublishingPluginSpec.groovy
@@ -16,6 +16,7 @@
 package nebula.plugin.bintray
 
 import nebula.test.PluginProjectSpec
+import org.gradle.api.UnknownTaskException
 
 class NebulaBintrayPublishingPluginSpec extends PluginProjectSpec {
     @Override
@@ -30,5 +31,21 @@ class NebulaBintrayPublishingPluginSpec extends PluginProjectSpec {
         then:
         project.tasks.getByName('publishPackageToBintray') != null
         project.tasks.getByName('publishVersionToBintray') != null
+    }
+
+    def 'apply plugin with componentsForExport'() {
+        when:
+          project.plugins.apply(NebulaBintrayPublishingPlugin)
+          project.configure(project) {
+              bintray {
+                  componentsForExport = []
+              }
+          }
+
+          project.tasks.getByName('publishMavenPublicationToBintrayRepository') == null
+
+        then:
+          def e = thrown(UnknownTaskException)
+          e.message.contains 'Task with name \'publishMavenPublicationToBintrayRepository\' not found'
     }
 }


### PR DESCRIPTION
Fix problem with non java projects

Problem looks like: 
```
Caused by: org.gradle.api.UnknownDomainObjectException: SoftwareComponentInternal with name 'java' not found.
```

It happens because nebula publishing plugin add components by name `'java'` in every project.