### PR TITLE
Add compatibility with Gradle 6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
         exclude(module = "groovy-all")
     }
     testImplementation("com.github.tomakehurst:wiremock:2.22.0")
+    testImplementation(gradleApi())
 }
 
 


### PR DESCRIPTION
GRADLE_METADATA is enable by default so all test has to expect with Gradle 6. To ensure same behaviour flag has to be added when test is running with Gradle 5.